### PR TITLE
Added auto folder creation feature for different users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-out
-out2
+/out-*
 *.txt
 node_modules

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const slugify = require('slugify')
 const { DateTime } = require('luxon')
 
 class Mylot {
-  static async generatePagePDF (article, force = false) {
+  static async generatePagePDF(article, username, force = false) {
     const browser = await puppeteer.launch({ headless: true })
     const page = await browser.newPage()
     await page.goto(article.url, { waitUntil: 'networkidle0' })
@@ -18,7 +18,13 @@ class Mylot {
     const dateRaw = await page.$eval('#discDat', el => el.innerText)
     const dateFormatted = DateTime.fromFormat(dateRaw.replace(' CST', ''), 'MMMM d, yyyy h:ma').toISODate()
 
-    const filename = `out/${dateFormatted}-${slug}.pdf`
+    const dir = `out-${username}`;
+
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir);
+    }
+
+    const filename = `${dir}/${dateFormatted}-${slug}.pdf`
 
     if (fs.existsSync(filename) && !force) {
       console.info(`PDF for article ${article.url} already exists, skipping`)
@@ -102,7 +108,7 @@ const getStartAction = html => {
   await async.mapLimit(articles, 5, async article => {
     console.info(`PDFing URL ${article.url}`)
     try {
-      await Mylot.generatePagePDF(article)
+      await Mylot.generatePagePDF(article, args[0])
     } catch (e) {
       console.error(`Error PDFing with URL ${article.url}, ${e.toString()}`)
     }


### PR DESCRIPTION
Follow up to my msg on reddit, I added the feature as I had suggested there.

> I found a tiny bug when duplicating your code. We need to manually create the "out" folder. Please automate the out folder creation in a way that each username gets a separate folder like "out-ridingbet", "out-atymic", etc

**Possible performance improvement:**
The check for folder existence occurs on every function run. I didn't know how to abstract it out.

Folder creation script copied from: https://stackoverflow.com/a/26815894/2365231 The discussion on it is worth a read to know the limitations.

I am not a javascript-onista so my approach may not be best practice. Feel free to reject and write your own version.